### PR TITLE
Rhacm2

### DIFF
--- a/multicluster/placement/base/policy/cluster_configuration_policy.yaml
+++ b/multicluster/placement/base/policy/cluster_configuration_policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: policy.mcm.ibm.com/v1alpha1
+apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
 metadata:
   name: cluster-configuration-policy

--- a/multicluster/placement/base/policy/cluster_upgrade_policy.yaml
+++ b/multicluster/placement/base/policy/cluster_upgrade_policy.yaml
@@ -4,9 +4,9 @@ metadata:
   name: cvo-policy
   namespace: cluster-configuration
   annotations:
-    policy.mcm.ibm.com/standards: NIST-CSF
-    policy.mcm.ibm.com/categories: PR.IP Information Protection Processes and Procedures
-    policy.mcm.ibm.com/controls: PR.IP-1 Baseline configuration
+    policy.open-cluster-management.io/standards: NIST SP 800-53
+    policy.open-cluster-management.io/categories: CM Configuration Management
+    policy.open-cluster-management.io/controls: CM-2 Baseline Configuration
 spec:
   complianceType: musthave
   remediationAction: enforce

--- a/multicluster/placement/base/policy/cluster_upgrade_policy.yaml
+++ b/multicluster/placement/base/policy/cluster_upgrade_policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: policy.mcm.ibm.com/v1alpha1
+apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
 metadata:
   name: cvo-policy

--- a/multicluster/placement/base/rule/placement_rule_cluster_policy.yaml
+++ b/multicluster/placement/base/rule/placement_rule_cluster_policy.yaml
@@ -4,7 +4,7 @@ kind: Namespace
 metadata:
   name: cluster-configuration
 ---
-apiVersion: mcm.ibm.com/v1alpha1
+apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
   name: cluster-configuration-policy
@@ -16,7 +16,7 @@ placementRef:
 subjects:
 - name: cluster-configuration-policy
   kind: Policy
-  apiGroup: policy.mcm.ibm.com
+  apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule

--- a/multicluster/placement/base/rule/placement_rule_cluster_policy.yaml
+++ b/multicluster/placement/base/rule/placement_rule_cluster_policy.yaml
@@ -4,7 +4,7 @@ kind: Namespace
 metadata:
   name: cluster-configuration
 ---
-apiVersion: apps.open-cluster-management.io/v1
+apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
   name: cluster-configuration-policy

--- a/multicluster/placement/base/rule/placement_rule_cvo.yaml
+++ b/multicluster/placement/base/rule/placement_rule_cvo.yaml
@@ -1,4 +1,4 @@
-apiVersion: mcm.ibm.com/v1alpha1
+apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
   name: cvo-policy
@@ -10,7 +10,7 @@ placementRef:
 subjects:
 - name: cvo-policy
   kind: Policy
-  apiGroup: policy.mcm.ibm.com
+  apiGroup: policy.open-cluster-management.io
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule


### PR DESCRIPTION
works in a ACM 2.0 Cluster maybe use another branch?

oc apply -k ./multicluster/placement/sites/sample_site
namespace/cluster-configuration unchanged
namespace/flexran-workloads unchanged
namespace/multus-networks unchanged
namespace/openshift-nfd unchanged
namespace/openshift-performance-addon unchanged
namespace/openshift-ptp unchanged
namespace/openshift-sriov-network-operator unchanged
channel.apps.open-cluster-management.io/acm-gitops-github unchanged
placementrule.apps.open-cluster-management.io/cluster-configuration-rule unchanged
placementrule.apps.open-cluster-management.io/cvo-rule unchanged
placementrule.apps.open-cluster-management.io/apply-multus-to-ready-clusters unchanged
placementrule.apps.open-cluster-management.io/apply-nfd-to-ready-clusters unchanged
placementrule.apps.open-cluster-management.io/apply-performance-to-ready-clusters unchanged
placementrule.apps.open-cluster-management.io/apply-ptp-to-ready-clusters unchanged
placementrule.apps.open-cluster-management.io/apply-sriov-to-ready-clusters unchanged
subscription.apps.open-cluster-management.io/flexran-multus-networks unchanged
subscription.apps.open-cluster-management.io/flexran-nfd unchanged
subscription.apps.open-cluster-management.io/flexran-performance unchanged
subscription.apps.open-cluster-management.io/flexran-ptp unchanged
subscription.apps.open-cluster-management.io/flexran-sriov unchanged
placementbinding.policy.open-cluster-management.io/cluster-configuration-policy created
placementbinding.policy.open-cluster-management.io/cvo-policy unchanged
policy.policy.open-cluster-management.io/cluster-configuration-policy unchanged
policy.policy.open-cluster-management.io/cvo-policy unchanged
